### PR TITLE
Add ZmqListener based message handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,10 +29,15 @@
   <properties>
     <java.version>17</java.version>
   </properties>
-  <dependencies>
+    <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.zeromq</groupId>
+      <artifactId>jeromq</artifactId>
+      <version>0.5.2</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/aoneconsultancy/zeromqpoc/zmq/DemoController.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/zmq/DemoController.java
@@ -1,0 +1,23 @@
+package com.aoneconsultancy.zeromqpoc.zmq;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+@RestController
+public class DemoController {
+
+    private final ZmqService zmqService;
+
+    public DemoController(ZmqService zmqService) {
+        this.zmqService = zmqService;
+    }
+
+    @GetMapping("/demo")
+    public DemoPayload sendDemo() throws Exception {
+        DemoPayload payload = new DemoPayload(1L, "Test", LocalDateTime.now());
+        zmqService.send(payload);
+        return payload;
+    }
+}

--- a/src/main/java/com/aoneconsultancy/zeromqpoc/zmq/DemoListener.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/zmq/DemoListener.java
@@ -1,0 +1,26 @@
+package com.aoneconsultancy.zeromqpoc.zmq;
+
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Simple component that receives {@link DemoPayload} messages using
+ * {@link ZmqListener} and prints them.
+ */
+@Component
+public class DemoListener {
+    private final BlockingQueue<DemoPayload> received = new LinkedBlockingQueue<>();
+
+    @ZmqListener
+    public void handle(DemoPayload payload) {
+        received.offer(payload);
+        System.out.println("@ZmqListener received: " + payload);
+    }
+
+    public DemoPayload poll(long timeout, TimeUnit unit) throws InterruptedException {
+        return received.poll(timeout, unit);
+    }
+}

--- a/src/main/java/com/aoneconsultancy/zeromqpoc/zmq/DemoPayload.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/zmq/DemoPayload.java
@@ -1,0 +1,19 @@
+package com.aoneconsultancy.zeromqpoc.zmq;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Simple payload used for demo purposes.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DemoPayload {
+    private long id;
+    private String name;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/aoneconsultancy/zeromqpoc/zmq/ZmqConfig.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/zmq/ZmqConfig.java
@@ -1,0 +1,21 @@
+package com.aoneconsultancy.zeromqpoc.zmq;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(ZmqProperties.class)
+public class ZmqConfig {
+
+    @Bean
+    public ZmqService zmqService(ZmqProperties properties) {
+        return new ZmqService(properties);
+    }
+
+    @Bean
+    public ZmqListenerBeanPostProcessor zmqListenerBeanPostProcessor(ZmqService zmqService, ObjectMapper mapper) {
+        return new ZmqListenerBeanPostProcessor(zmqService, mapper);
+    }
+}

--- a/src/main/java/com/aoneconsultancy/zeromqpoc/zmq/ZmqListener.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/zmq/ZmqListener.java
@@ -1,0 +1,15 @@
+package com.aoneconsultancy.zeromqpoc.zmq;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation for methods that should receive messages from the
+ * ZeroMQ PULL socket.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ZmqListener {
+}

--- a/src/main/java/com/aoneconsultancy/zeromqpoc/zmq/ZmqListenerBeanPostProcessor.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/zmq/ZmqListenerBeanPostProcessor.java
@@ -1,0 +1,54 @@
+package com.aoneconsultancy.zeromqpoc.zmq;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.lang.NonNull;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Method;
+import java.util.function.Consumer;
+
+/**
+ * Registers methods annotated with {@link ZmqListener} to receive messages
+ * from {@link ZmqService}.
+ */
+public class ZmqListenerBeanPostProcessor implements BeanPostProcessor {
+
+    private final ZmqService zmqService;
+    private final ObjectMapper mapper;
+
+    public ZmqListenerBeanPostProcessor(ZmqService zmqService, ObjectMapper mapper) {
+        this.zmqService = zmqService;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(@NonNull Object bean, @NonNull String beanName) throws BeansException {
+        Class<?> targetClass = bean.getClass();
+        ReflectionUtils.doWithMethods(targetClass, method -> registerMethod(bean, method),
+                method -> method.isAnnotationPresent(ZmqListener.class));
+        return bean;
+    }
+
+    private void registerMethod(Object bean, Method method) {
+        Class<?> paramType = method.getParameterCount() == 1 ? method.getParameterTypes()[0] : byte[].class;
+        method.setAccessible(true);
+        Consumer<byte[]> listener = bytes -> {
+            try {
+                Object arg;
+                if (paramType == byte[].class) {
+                    arg = bytes;
+                } else if (paramType == String.class) {
+                    arg = new String(bytes);
+                } else {
+                    arg = mapper.readValue(bytes, paramType);
+                }
+                method.invoke(bean, arg);
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to invoke ZmqListener method", e);
+            }
+        };
+        zmqService.registerListener(listener);
+    }
+}

--- a/src/main/java/com/aoneconsultancy/zeromqpoc/zmq/ZmqProperties.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/zmq/ZmqProperties.java
@@ -1,0 +1,40 @@
+package com.aoneconsultancy.zeromqpoc.zmq;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "zeromq")
+public class ZmqProperties {
+
+    /** Address where push socket will bind, e.g. tcp://*:5555 */
+    private String pushBindAddress = "tcp://*:5555";
+
+    /** Address where pull socket connects to, e.g. tcp://localhost:5555 */
+    private String pullConnectAddress = "tcp://localhost:5555";
+
+    /** High water mark / buffer size for sockets */
+    private int bufferSize = 1000;
+
+    public String getPushBindAddress() {
+        return pushBindAddress;
+    }
+
+    public void setPushBindAddress(String pushBindAddress) {
+        this.pushBindAddress = pushBindAddress;
+    }
+
+    public String getPullConnectAddress() {
+        return pullConnectAddress;
+    }
+
+    public void setPullConnectAddress(String pullConnectAddress) {
+        this.pullConnectAddress = pullConnectAddress;
+    }
+
+    public int getBufferSize() {
+        return bufferSize;
+    }
+
+    public void setBufferSize(int bufferSize) {
+        this.bufferSize = bufferSize;
+    }
+}

--- a/src/main/java/com/aoneconsultancy/zeromqpoc/zmq/ZmqService.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/zmq/ZmqService.java
@@ -1,0 +1,80 @@
+package com.aoneconsultancy.zeromqpoc.zmq;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.DisposableBean;
+import org.zeromq.SocketType;
+import org.zeromq.ZContext;
+import org.zeromq.ZMQ;
+
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * Service that manages ZeroMQ push/pull sockets.
+ */
+public class ZmqService implements DisposableBean {
+    private final ZmqProperties properties;
+    private final ZContext context = new ZContext();
+    private final ZMQ.Socket pushSocket;
+    private final ZMQ.Socket pullSocket;
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final BlockingQueue<String> receivedMessages = new LinkedBlockingQueue<>();
+    private final ExecutorService listenerExecutor = Executors.newSingleThreadExecutor();
+    private final List<Consumer<byte[]>> listeners = new CopyOnWriteArrayList<>();
+
+    public ZmqService(ZmqProperties properties) {
+        this.properties = properties;
+        pushSocket = context.createSocket(SocketType.PUSH);
+        pushSocket.setHWM(properties.getBufferSize());
+        pushSocket.bind(properties.getPushBindAddress());
+
+        pullSocket = context.createSocket(SocketType.PULL);
+        pullSocket.setHWM(properties.getBufferSize());
+        pullSocket.connect(properties.getPullConnectAddress());
+    }
+
+    @PostConstruct
+    public void startListener() {
+        listenerExecutor.submit(() -> {
+            while (!Thread.currentThread().isInterrupted()) {
+                byte[] data = pullSocket.recv(0);
+                if (data != null) {
+                    String json = new String(data);
+                    System.out.println("Received: " + json);
+                    receivedMessages.offer(json);
+                    for (Consumer<byte[]> listener : listeners) {
+                        listener.accept(data);
+                    }
+                }
+            }
+        });
+    }
+
+    public void send(Object payload) throws JsonProcessingException {
+        pushSocket.send(mapper.writeValueAsBytes(payload), 0);
+    }
+
+    public void registerListener(Consumer<byte[]> listener) {
+        listeners.add(listener);
+    }
+
+    public String pollReceived(long timeout, TimeUnit unit) throws InterruptedException {
+        return receivedMessages.poll(timeout, unit);
+    }
+
+    @Override
+    public void destroy() {
+        listenerExecutor.shutdownNow();
+        pushSocket.close();
+        pullSocket.close();
+        context.close();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,8 @@
 spring:
   application:
     name: zeromq-poc
+
+zeromq:
+  push-bind-address: tcp://*:5555
+  pull-connect-address: tcp://localhost:5555
+  buffer-size: 1000

--- a/src/test/java/com/aoneconsultancy/zeromqpoc/ZmqIntegrationTest.java
+++ b/src/test/java/com/aoneconsultancy/zeromqpoc/ZmqIntegrationTest.java
@@ -1,0 +1,44 @@
+package com.aoneconsultancy.zeromqpoc;
+
+import com.aoneconsultancy.zeromqpoc.zmq.DemoListener;
+import com.aoneconsultancy.zeromqpoc.zmq.DemoPayload;
+import com.aoneconsultancy.zeromqpoc.zmq.ZmqService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ZmqIntegrationTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    TestRestTemplate restTemplate;
+
+    @Autowired
+    ZmqService zmqService;
+
+    @Autowired
+    DemoListener demoListener;
+
+    @Test
+    void sendEndpointShouldSendAndReceiveMessage() throws Exception {
+        DemoPayload response = restTemplate.getForObject("http://localhost:" + port + "/demo", DemoPayload.class);
+        assertThat(response.getId()).isEqualTo(1L);
+        String receivedJson = zmqService.pollReceived(5, TimeUnit.SECONDS);
+        assertThat(receivedJson).isNotNull();
+        assertThat(receivedJson).contains("\"id\":1");
+        assertThat(receivedJson).contains("\"name\":\"Test\"");
+
+        DemoPayload received = demoListener.poll(5, TimeUnit.SECONDS);
+        assertThat(received).isNotNull();
+        assertThat(received.getName()).isEqualTo("Test");
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `@ZmqListener` annotation and processor
- allow `ZmqService` to register listeners
- print received messages in `DemoListener` using the new annotation
- switch `DemoPayload` to Lombok
- extend integration test to verify listener invocation

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*