### PR TITLE
Switch to ZeroMqProxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,11 @@
       <artifactId>jeromq</artifactId>
       <version>0.5.2</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.integration</groupId>
+      <artifactId>spring-integration-zeromq</artifactId>
+      <version>6.5.0</version>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/aoneconsultancy/zeromqpoc/config/ZmqConfig.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/config/ZmqConfig.java
@@ -3,6 +3,8 @@ package com.aoneconsultancy.zeromqpoc.config;
 import com.aoneconsultancy.zeromqpoc.service.ZmqService;
 import com.aoneconsultancy.zeromqpoc.service.listener.ZmqListenerBeanPostProcessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.integration.zeromq.ZeroMqProxy;
+import org.zeromq.ZContext;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,12 +14,26 @@ import org.springframework.context.annotation.Configuration;
 public class ZmqConfig {
 
     @Bean
-    public ZmqService zmqService(ZmqProperties properties) {
-        return new ZmqService(properties);
+    public ZeroMqProxy zeroMqProxy(ZmqProperties properties) {
+        ZContext context = new ZContext();
+        ZeroMqProxy proxy = new ZeroMqProxy(context, ZeroMqProxy.Type.PULL_PUSH);
+        proxy.setFrontendPort(extractPort(properties.getPushBindAddress()));
+        proxy.setBackendPort(extractPort(properties.getPullConnectAddress()));
+        return proxy;
+    }
+
+    @Bean
+    public ZmqService zmqService(ZmqProperties properties, ZeroMqProxy zeroMqProxy) {
+        return new ZmqService(properties, zeroMqProxy);
     }
 
     @Bean
     public ZmqListenerBeanPostProcessor zmqListenerBeanPostProcessor(ZmqService zmqService, ObjectMapper mapper) {
         return new ZmqListenerBeanPostProcessor(zmqService, mapper);
+    }
+
+    private int extractPort(String address) {
+        int index = address.lastIndexOf(':');
+        return index > 0 ? Integer.parseInt(address.substring(index + 1)) : 0;
     }
 }


### PR DESCRIPTION
## Summary
- add `spring-integration-zeromq` dependency
- configure a `ZeroMqProxy` bean
- wire `ZmqService` to use the proxy instead of managing a `ZContext`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch dependencies due to network)*