### PR TITLE
Add ZeroMQ template and container concurrency

### DIFF
--- a/src/main/java/com/aoneconsultancy/zeromqpoc/config/ZmqConfig.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/config/ZmqConfig.java
@@ -1,7 +1,10 @@
 package com.aoneconsultancy.zeromqpoc.config;
 
 import com.aoneconsultancy.zeromqpoc.service.ZmqService;
+import com.aoneconsultancy.zeromqpoc.service.ZmqTemplate;
+import com.aoneconsultancy.zeromqpoc.service.listener.SimpleZmqListenerContainerFactory;
 import com.aoneconsultancy.zeromqpoc.service.listener.ZmqListenerBeanPostProcessor;
+import com.aoneconsultancy.zeromqpoc.service.listener.ZmqListenerContainerFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.integration.zeromq.ZeroMqProxy;
 import org.zeromq.ZContext;
@@ -28,8 +31,20 @@ public class ZmqConfig {
     }
 
     @Bean
-    public ZmqListenerBeanPostProcessor zmqListenerBeanPostProcessor(ZmqService zmqService, ObjectMapper mapper) {
-        return new ZmqListenerBeanPostProcessor(zmqService, mapper);
+    public ZmqTemplate zmqTemplate(ZmqService zmqService, ObjectMapper mapper) {
+        return new ZmqTemplate(zmqService, mapper);
+    }
+
+    @Bean
+    public ZmqListenerContainerFactory<?> zmqListenerContainerFactory(ZmqService zmqService,
+                                                                      ZmqProperties properties) {
+        return new SimpleZmqListenerContainerFactory(zmqService, properties);
+    }
+
+    @Bean
+    public ZmqListenerBeanPostProcessor zmqListenerBeanPostProcessor(ZmqListenerContainerFactory<?> factory,
+                                                                    ObjectMapper mapper) {
+        return new ZmqListenerBeanPostProcessor(factory, mapper);
     }
 
     private int extractPort(String address) {

--- a/src/main/java/com/aoneconsultancy/zeromqpoc/config/ZmqProperties.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/config/ZmqProperties.java
@@ -14,6 +14,9 @@ public class ZmqProperties {
     /** High water mark / buffer size for sockets */
     private int bufferSize = 1000;
 
+    /** Number of threads for {@link com.aoneconsultancy.zeromqpoc.service.listener.ZmqListenerContainer}. */
+    private int listenerConcurrency = 1;
+
     public String getPushBindAddress() {
         return pushBindAddress;
     }
@@ -36,5 +39,13 @@ public class ZmqProperties {
 
     public void setBufferSize(int bufferSize) {
         this.bufferSize = bufferSize;
+    }
+
+    public int getListenerConcurrency() {
+        return listenerConcurrency;
+    }
+
+    public void setListenerConcurrency(int listenerConcurrency) {
+        this.listenerConcurrency = listenerConcurrency;
     }
 }

--- a/src/main/java/com/aoneconsultancy/zeromqpoc/controller/DemoController.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/controller/DemoController.java
@@ -1,7 +1,7 @@
 package com.aoneconsultancy.zeromqpoc.controller;
 
 import com.aoneconsultancy.zeromqpoc.model.payload.DemoPayload;
-import com.aoneconsultancy.zeromqpoc.service.ZmqService;
+import com.aoneconsultancy.zeromqpoc.service.ZmqTemplate;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,10 +10,10 @@ import java.time.LocalDateTime;
 @RestController
 public class DemoController {
 
-    private final ZmqService zmqService;
+    private final ZmqTemplate zmqTemplate;
 
-    public DemoController(ZmqService zmqService) {
-        this.zmqService = zmqService;
+    public DemoController(ZmqTemplate zmqTemplate) {
+        this.zmqTemplate = zmqTemplate;
     }
 
     @GetMapping("/demo")
@@ -23,7 +23,7 @@ public class DemoController {
                 .name("Test")
                 .createdAt(LocalDateTime.now())
                 .build();
-        zmqService.send(payload);
+        zmqTemplate.convertAndSend(payload);
         return payload;
     }
 }

--- a/src/main/java/com/aoneconsultancy/zeromqpoc/service/ZmqService.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/service/ZmqService.java
@@ -65,12 +65,24 @@ public class ZmqService implements DisposableBean {
         });
     }
 
+    public void sendBytes(byte[] data) {
+        pushSocket.send(data, 0);
+    }
+
     public void send(Object payload) throws JsonProcessingException {
-        pushSocket.send(mapper.writeValueAsBytes(payload), 0);
+        sendBytes(mapper.writeValueAsBytes(payload));
     }
 
     public void registerListener(Consumer<byte[]> listener) {
         listeners.add(listener);
+    }
+
+    /**
+     * Remove a previously registered listener.
+     * @param listener the listener to remove
+     */
+    public void unregisterListener(Consumer<byte[]> listener) {
+        listeners.remove(listener);
     }
 
     public String pollReceived(long timeout, TimeUnit unit) throws InterruptedException {

--- a/src/main/java/com/aoneconsultancy/zeromqpoc/service/ZmqTemplate.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/service/ZmqTemplate.java
@@ -1,0 +1,39 @@
+package com.aoneconsultancy.zeromqpoc.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Simplified helper similar to Spring's {@code RabbitTemplate} for sending
+ * messages over ZeroMQ.
+ */
+public class ZmqTemplate {
+
+    private final ZmqService zmqService;
+    private final ObjectMapper mapper;
+
+    public ZmqTemplate(ZmqService zmqService, ObjectMapper mapper) {
+        this.zmqService = zmqService;
+        this.mapper = mapper;
+    }
+
+    /**
+     * Send a pre-serialized byte array.
+     * @param payload the bytes to send
+     */
+    public void sendBytes(byte[] payload) {
+        zmqService.sendBytes(payload);
+    }
+
+    /**
+     * Convert the payload to JSON and send it.
+     * @param payload the object to serialize
+     */
+    public void convertAndSend(Object payload) {
+        try {
+            zmqService.sendBytes(mapper.writeValueAsBytes(payload));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize payload", e);
+        }
+    }
+}

--- a/src/main/java/com/aoneconsultancy/zeromqpoc/service/listener/SimpleZmqListenerContainer.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/service/listener/SimpleZmqListenerContainer.java
@@ -1,0 +1,60 @@
+package com.aoneconsultancy.zeromqpoc.service.listener;
+
+import com.aoneconsultancy.zeromqpoc.service.ZmqService;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+
+/**
+ * Default {@link ZmqListenerContainer} implementation backed by {@link ZmqService}.
+ */
+public class SimpleZmqListenerContainer implements ZmqListenerContainer {
+
+    private final ZmqService zmqService;
+    private Consumer<byte[]> listener;
+    private Consumer<byte[]> internalListener;
+    private boolean running;
+    private int concurrency = 1;
+    private ExecutorService executor;
+
+    public SimpleZmqListenerContainer(ZmqService zmqService) {
+        this.zmqService = zmqService;
+    }
+
+    @Override
+    public void setMessageListener(Consumer<byte[]> listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    public void start() {
+        if (!running && listener != null) {
+            this.executor = Executors.newFixedThreadPool(concurrency);
+            this.internalListener = bytes -> executor.execute(() -> listener.accept(bytes));
+            zmqService.registerListener(internalListener);
+            running = true;
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (running && internalListener != null) {
+            zmqService.unregisterListener(internalListener);
+            executor.shutdown();
+            running = false;
+        }
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
+
+    /**
+     * Configure the number of threads used to invoke the listener.
+     */
+    public void setConcurrency(int concurrency) {
+        this.concurrency = concurrency;
+    }
+}

--- a/src/main/java/com/aoneconsultancy/zeromqpoc/service/listener/SimpleZmqListenerContainerFactory.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/service/listener/SimpleZmqListenerContainerFactory.java
@@ -1,0 +1,28 @@
+package com.aoneconsultancy.zeromqpoc.service.listener;
+
+import com.aoneconsultancy.zeromqpoc.config.ZmqProperties;
+import com.aoneconsultancy.zeromqpoc.service.ZmqService;
+
+import java.util.function.Consumer;
+
+/**
+ * Default factory that creates {@link SimpleZmqListenerContainer} instances.
+ */
+public class SimpleZmqListenerContainerFactory implements ZmqListenerContainerFactory<SimpleZmqListenerContainer> {
+
+    private final ZmqService zmqService;
+    private final ZmqProperties properties;
+
+    public SimpleZmqListenerContainerFactory(ZmqService zmqService, ZmqProperties properties) {
+        this.zmqService = zmqService;
+        this.properties = properties;
+    }
+
+    @Override
+    public SimpleZmqListenerContainer createContainer(Consumer<byte[]> listener) {
+        SimpleZmqListenerContainer container = new SimpleZmqListenerContainer(zmqService);
+        container.setMessageListener(listener);
+        container.setConcurrency(properties.getListenerConcurrency());
+        return container;
+    }
+}

--- a/src/main/java/com/aoneconsultancy/zeromqpoc/service/listener/ZmqListenerBeanPostProcessor.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/service/listener/ZmqListenerBeanPostProcessor.java
@@ -16,11 +16,11 @@ import java.util.function.Consumer;
  */
 public class ZmqListenerBeanPostProcessor implements BeanPostProcessor {
 
-    private final ZmqService zmqService;
+    private final ZmqListenerContainerFactory<? extends ZmqListenerContainer> containerFactory;
     private final ObjectMapper mapper;
-
-    public ZmqListenerBeanPostProcessor(ZmqService zmqService, ObjectMapper mapper) {
-        this.zmqService = zmqService;
+    public ZmqListenerBeanPostProcessor(ZmqListenerContainerFactory<? extends ZmqListenerContainer> containerFactory,
+                                        ObjectMapper mapper) {
+        this.containerFactory = containerFactory;
         this.mapper = mapper;
     }
 
@@ -50,6 +50,7 @@ public class ZmqListenerBeanPostProcessor implements BeanPostProcessor {
                 throw new RuntimeException("Failed to invoke ZmqListener method", e);
             }
         };
-        zmqService.registerListener(listener);
+        ZmqListenerContainer container = containerFactory.createContainer(listener);
+        container.start();
     }
 }

--- a/src/main/java/com/aoneconsultancy/zeromqpoc/service/listener/ZmqListenerContainer.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/service/listener/ZmqListenerContainer.java
@@ -1,0 +1,26 @@
+package com.aoneconsultancy.zeromqpoc.service.listener;
+
+import java.util.function.Consumer;
+
+/**
+ * Simple abstraction representing a ZeroMQ message listener container.
+ */
+public interface ZmqListenerContainer {
+
+    /**
+     * Set the listener that will receive raw message bytes.
+     * @param listener consumer of the received bytes
+     */
+    void setMessageListener(Consumer<byte[]> listener);
+
+    /** Start listening for messages. */
+    void start();
+
+    /** Stop listening for messages. */
+    void stop();
+
+    /**
+     * @return whether the container is currently running
+     */
+    boolean isRunning();
+}

--- a/src/main/java/com/aoneconsultancy/zeromqpoc/service/listener/ZmqListenerContainerFactory.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/service/listener/ZmqListenerContainerFactory.java
@@ -1,0 +1,16 @@
+package com.aoneconsultancy.zeromqpoc.service.listener;
+
+import java.util.function.Consumer;
+
+/**
+ * Factory for creating {@link ZmqListenerContainer} instances.
+ */
+public interface ZmqListenerContainerFactory<T extends ZmqListenerContainer> {
+
+    /**
+     * Create a listener container configured with the given message listener.
+     * @param listener consumer for received bytes
+     * @return new container instance
+     */
+    T createContainer(Consumer<byte[]> listener);
+}


### PR DESCRIPTION
## Summary
- add `listenerConcurrency` option to `ZmqProperties`
- support concurrent processing in `SimpleZmqListenerContainer`
- introduce `ZmqTemplate` for sending raw bytes or objects
- wire template and factory beans in `ZmqConfig`
- use the template in `DemoController`

## Testing
- `mvn -q test` *(fails: Could not download dependencies)*