### PR TITLE
Add default ZMQ listener registry

### DIFF
--- a/src/main/java/com/aoneconsultancy/zeromqpoc/config/ZmqAutoConfiguration.java
+++ b/src/main/java/com/aoneconsultancy/zeromqpoc/config/ZmqAutoConfiguration.java
@@ -5,6 +5,8 @@ import com.aoneconsultancy.zeromqpoc.core.converter.Jackson2JsonMessageConverter
 import com.aoneconsultancy.zeromqpoc.core.converter.MessageConverter;
 import com.aoneconsultancy.zeromqpoc.listener.SimpleZmqListenerContainerFactory;
 import com.aoneconsultancy.zeromqpoc.listener.ZmqListenerContainerFactory;
+import com.aoneconsultancy.zeromqpoc.listener.endpoint.ZmqListenerEndpointRegistry;
+import com.aoneconsultancy.zeromqpoc.config.ZmqListenerConfigUtils;
 import com.aoneconsultancy.zeromqpoc.service.ZmqTemplate;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.concurrent.TimeUnit;
@@ -80,8 +82,17 @@ public class ZmqAutoConfiguration {
 
         @Bean
         @ConditionalOnMissingBean
-        public ZmqListenerBeanPostProcessor zmqListenerBeanPostProcessor() {
-            return new ZmqListenerBeanPostProcessor();
+        public ZmqListenerEndpointRegistry zmqListenerEndpointRegistry() {
+            return new ZmqListenerEndpointRegistry();
+        }
+
+        @Bean
+        @ConditionalOnMissingBean
+        public ZmqListenerBeanPostProcessor zmqListenerBeanPostProcessor(
+                ZmqListenerEndpointRegistry registry) {
+            ZmqListenerBeanPostProcessor processor = new ZmqListenerBeanPostProcessor();
+            processor.setEndpointRegistry(registry);
+            return processor;
         }
     }
 }


### PR DESCRIPTION
## Summary
- auto-configure `ZmqListenerEndpointRegistry`
- wire registry into `ZmqListenerBeanPostProcessor`

## Testing
- `mvnw test` *(fails: Failed to fetch https://repo.maven.apache.org/... because the environment lacks network access)*

------
https://chatgpt.com/codex/tasks/task_b_683d3ba332e4832eb9ed4b7c74f6b6af